### PR TITLE
require at least one argument for vararg

### DIFF
--- a/.changes/generativeai/decision-amount-amusement-bite.json
+++ b/.changes/generativeai/decision-amount-amusement-bite.json
@@ -1,0 +1,1 @@
+{"type":"PATCH","changes":["Require at least one argument for functions that take vararg"]}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/Chat.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/Chat.kt
@@ -57,7 +57,7 @@ class Chat(private val model: GenerativeModel, val history: MutableList<Content>
     prompt.assertComesFromUser()
     attemptLock()
     try {
-      val response = model.generateContent(*history.toTypedArray(), prompt)
+      val response = model.generateContent(prompt, *history.toTypedArray())
       history.add(prompt)
       history.add(response.candidates.first().content)
       return response
@@ -100,7 +100,7 @@ class Chat(private val model: GenerativeModel, val history: MutableList<Content>
     prompt.assertComesFromUser()
     attemptLock()
 
-    val flow = model.generateContentStream(*history.toTypedArray(), prompt)
+    val flow = model.generateContentStream(prompt, *history.toTypedArray())
     val bitmaps = LinkedList<Bitmap>()
     val blobs = LinkedList<BlobPart>()
     val text = StringBuilder()

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -105,9 +105,9 @@ internal constructor(
    * @return A [GenerateContentResponse] after some delay. Function should be called within a
    *   suspend context to properly manage concurrency.
    */
-  suspend fun generateContent(vararg prompt: Content): GenerateContentResponse =
+  suspend fun generateContent(prompt: Content, vararg prompts: Content): GenerateContentResponse =
     try {
-      controller.generateContent(constructRequest(*prompt)).toPublic().validate()
+      controller.generateContent(constructRequest(prompt, *prompts)).toPublic().validate()
     } catch (e: Throwable) {
       throw GoogleGenerativeAIException.from(e)
     }
@@ -118,9 +118,9 @@ internal constructor(
    * @param prompt A group of [Content]s to send to the model.
    * @return A [Flow] which will emit responses as they are returned from the model.
    */
-  fun generateContentStream(vararg prompt: Content): Flow<GenerateContentResponse> =
+  fun generateContentStream(prompt: Content, vararg prompts: Content): Flow<GenerateContentResponse> =
     controller
-      .generateContentStream(constructRequest(*prompt))
+      .generateContentStream(constructRequest(prompt, *prompts))
       .catch { throw GoogleGenerativeAIException.from(it) }
       .map { it.toPublic().validate() }
 
@@ -171,8 +171,8 @@ internal constructor(
    * @param prompt A group of [Content]s to count tokens of.
    * @return A [CountTokensResponse] containing the number of tokens in the prompt.
    */
-  suspend fun countTokens(vararg prompt: Content): CountTokensResponse {
-    return controller.countTokens(constructCountTokensRequest(*prompt)).toPublic()
+  suspend fun countTokens(prompt: Content, vararg prompts: Content): CountTokensResponse {
+    return controller.countTokens(constructCountTokensRequest(prompt, *prompts)).toPublic()
   }
 
   /**

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -118,7 +118,10 @@ internal constructor(
    * @param prompt A group of [Content]s to send to the model.
    * @return A [Flow] which will emit responses as they are returned from the model.
    */
-  fun generateContentStream(prompt: Content, vararg prompts: Content): Flow<GenerateContentResponse> =
+  fun generateContentStream(
+    prompt: Content,
+    vararg prompts: Content
+  ): Flow<GenerateContentResponse> =
     controller
       .generateContentStream(constructRequest(prompt, *prompts))
       .catch { throw GoogleGenerativeAIException.from(it) }

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/java/GenerativeModelFutures.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/java/GenerativeModelFutures.kt
@@ -38,21 +38,30 @@ abstract class GenerativeModelFutures internal constructor() {
    *
    * @param prompt A group of [Content]s to send to the model.
    */
-  abstract fun generateContent(prompt: Content, vararg prompts: Content): ListenableFuture<GenerateContentResponse>
+  abstract fun generateContent(
+    prompt: Content,
+    vararg prompts: Content
+  ): ListenableFuture<GenerateContentResponse>
 
   /**
    * Generates a streaming response from the backend with the provided [Content]s.
    *
    * @param prompt A group of [Content]s to send to the model.
    */
-  abstract fun generateContentStream(prompt: Content, vararg prompts: Content): Publisher<GenerateContentResponse>
+  abstract fun generateContentStream(
+    prompt: Content,
+    vararg prompts: Content
+  ): Publisher<GenerateContentResponse>
 
   /**
    * Counts the number of tokens used in a prompt.
    *
    * @param prompt A group of [Content]s to count tokens of.
    */
-  abstract fun countTokens(prompt: Content, vararg prompts: Content): ListenableFuture<CountTokensResponse>
+  abstract fun countTokens(
+    prompt: Content,
+    vararg prompts: Content
+  ): ListenableFuture<CountTokensResponse>
 
   /** Creates a chat instance which internally tracks the ongoing conversation with the model */
   abstract fun startChat(): ChatFutures
@@ -74,10 +83,16 @@ abstract class GenerativeModelFutures internal constructor() {
     ): ListenableFuture<GenerateContentResponse> =
       SuspendToFutureAdapter.launchFuture { model.generateContent(prompt, *prompts) }
 
-    override fun generateContentStream(prompt: Content, vararg prompts: Content): Publisher<GenerateContentResponse> =
+    override fun generateContentStream(
+      prompt: Content,
+      vararg prompts: Content
+    ): Publisher<GenerateContentResponse> =
       model.generateContentStream(prompt, *prompts).asPublisher()
 
-    override fun countTokens(prompt: Content, vararg prompts: Content): ListenableFuture<CountTokensResponse> =
+    override fun countTokens(
+      prompt: Content,
+      vararg prompts: Content
+    ): ListenableFuture<CountTokensResponse> =
       SuspendToFutureAdapter.launchFuture { model.countTokens(prompt, *prompts) }
 
     override fun startChat(): ChatFutures = startChat(emptyList())

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/java/GenerativeModelFutures.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/java/GenerativeModelFutures.kt
@@ -38,21 +38,21 @@ abstract class GenerativeModelFutures internal constructor() {
    *
    * @param prompt A group of [Content]s to send to the model.
    */
-  abstract fun generateContent(vararg prompt: Content): ListenableFuture<GenerateContentResponse>
+  abstract fun generateContent(prompt: Content, vararg prompts: Content): ListenableFuture<GenerateContentResponse>
 
   /**
    * Generates a streaming response from the backend with the provided [Content]s.
    *
    * @param prompt A group of [Content]s to send to the model.
    */
-  abstract fun generateContentStream(vararg prompt: Content): Publisher<GenerateContentResponse>
+  abstract fun generateContentStream(prompt: Content, vararg prompts: Content): Publisher<GenerateContentResponse>
 
   /**
    * Counts the number of tokens used in a prompt.
    *
    * @param prompt A group of [Content]s to count tokens of.
    */
-  abstract fun countTokens(vararg prompt: Content): ListenableFuture<CountTokensResponse>
+  abstract fun countTokens(prompt: Content, vararg prompts: Content): ListenableFuture<CountTokensResponse>
 
   /** Creates a chat instance which internally tracks the ongoing conversation with the model */
   abstract fun startChat(): ChatFutures
@@ -69,15 +69,16 @@ abstract class GenerativeModelFutures internal constructor() {
 
   private class FuturesImpl(private val model: GenerativeModel) : GenerativeModelFutures() {
     override fun generateContent(
-      vararg prompt: Content
+      prompt: Content,
+      vararg prompts: Content
     ): ListenableFuture<GenerateContentResponse> =
-      SuspendToFutureAdapter.launchFuture { model.generateContent(*prompt) }
+      SuspendToFutureAdapter.launchFuture { model.generateContent(prompt, *prompts) }
 
-    override fun generateContentStream(vararg prompt: Content): Publisher<GenerateContentResponse> =
-      model.generateContentStream(*prompt).asPublisher()
+    override fun generateContentStream(prompt: Content, vararg prompts: Content): Publisher<GenerateContentResponse> =
+      model.generateContentStream(prompt, *prompts).asPublisher()
 
-    override fun countTokens(vararg prompt: Content): ListenableFuture<CountTokensResponse> =
-      SuspendToFutureAdapter.launchFuture { model.countTokens(*prompt) }
+    override fun countTokens(prompt: Content, vararg prompts: Content): ListenableFuture<CountTokensResponse> =
+      SuspendToFutureAdapter.launchFuture { model.countTokens(prompt, *prompts) }
 
     override fun startChat(): ChatFutures = startChat(emptyList())
 


### PR DESCRIPTION
In its current state, `generateContent()`, `generateContentStream()` and `countTokens()` let developers pass zero arguments, which then causes the runtime error:
`com.google.ai.client.generativeai.type.ServerException: * GenerateContentRequest.contents: contents is not specified` - because `contents` is a required field on the API.

Although the current error might be helpful, it would be nice if a developer could spot this mistake in compile time rather than in runtime.

### Backwards compatibility

The changes in this PR would probably not break most of the cases that we have documented (eg. `countTokens(content)`), but would certainly break a few cases like for example if the developer was doing something like `countTokens(*contentArray, content)` (which we actually document [here](https://ai.google.dev/tutorials/get_started_android#count-tokens)).