### PR TITLE
Remove usages of Beta flag

### DIFF
--- a/.changes/generativeai/cork-dock-apple-cobweb.json
+++ b/.changes/generativeai/cork-dock-apple-cobweb.json
@@ -1,0 +1,1 @@
+{"type":"PATCH","changes":["Remove usages of v1beta opt-in flag"]}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -29,7 +29,6 @@ import com.google.ai.client.generativeai.type.FourParameterFunction
 import com.google.ai.client.generativeai.type.FunctionCallPart
 import com.google.ai.client.generativeai.type.GenerateContentResponse
 import com.google.ai.client.generativeai.type.GenerationConfig
-import com.google.ai.client.generativeai.type.GenerativeBeta
 import com.google.ai.client.generativeai.type.GoogleGenerativeAIException
 import com.google.ai.client.generativeai.type.InvalidStateException
 import com.google.ai.client.generativeai.type.NoParameterFunction
@@ -206,7 +205,6 @@ internal constructor(
    *   parameters
    * @return The output of the requested function call
    */
-  @OptIn(GenerativeBeta::class)
   suspend fun executeFunction(functionCallPart: FunctionCallPart): JSONObject {
     if (tools == null) {
       throw InvalidStateException("No registered tools")
@@ -230,7 +228,6 @@ internal constructor(
     }
   }
 
-  @OptIn(GenerativeBeta::class)
   private fun constructRequest(vararg prompt: Content) =
     GenerateContentRequest(
       modelName,

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
@@ -49,7 +49,6 @@ import com.google.ai.client.generativeai.type.BlockThreshold
 import com.google.ai.client.generativeai.type.CitationMetadata
 import com.google.ai.client.generativeai.type.FunctionCallingConfig
 import com.google.ai.client.generativeai.type.FunctionDeclaration
-import com.google.ai.client.generativeai.type.GenerativeBeta
 import com.google.ai.client.generativeai.type.ImagePart
 import com.google.ai.client.generativeai.type.SerializationException
 import com.google.ai.client.generativeai.type.Tool
@@ -120,11 +119,9 @@ internal fun BlockThreshold.toInternal() =
     BlockThreshold.UNSPECIFIED -> HarmBlockThreshold.UNSPECIFIED
   }
 
-@GenerativeBeta
 internal fun Tool.toInternal() =
   com.google.ai.client.generativeai.common.client.Tool(functionDeclarations.map { it.toInternal() })
 
-@GenerativeBeta
 internal fun ToolConfig.toInternal() =
   com.google.ai.client.generativeai.common.client.ToolConfig(
     com.google.ai.client.generativeai.common.client.FunctionCallingConfig(
@@ -139,7 +136,6 @@ internal fun ToolConfig.toInternal() =
     )
   )
 
-@GenerativeBeta
 internal fun FunctionDeclaration.toInternal() =
   com.google.ai.client.generativeai.common.client.FunctionDeclaration(
     name,

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionCallingConfig.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionCallingConfig.kt
@@ -22,7 +22,6 @@ package com.google.ai.client.generativeai.type
  *
  * @param mode The function calling mode of the model
  */
-@GenerativeBeta
 class FunctionCallingConfig(val mode: Mode) {
   enum class Mode {
     /**

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionDeclarations.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionDeclarations.kt
@@ -26,7 +26,6 @@ import org.json.JSONObject
  * @property description A description of what the function does and its output.
  * @property function the function implementation
  */
-@GenerativeBeta
 class NoParameterFunction(
   name: String,
   description: String,
@@ -48,7 +47,6 @@ class NoParameterFunction(
  * @property param A description of the first function parameter
  * @property function the function implementation
  */
-@GenerativeBeta
 class OneParameterFunction<T>(
   name: String,
   description: String,
@@ -73,7 +71,6 @@ class OneParameterFunction<T>(
  * @property param2 A description of the second function parameter
  * @property function the function implementation
  */
-@GenerativeBeta
 class TwoParameterFunction<T, U>(
   name: String,
   description: String,
@@ -101,7 +98,6 @@ class TwoParameterFunction<T, U>(
  * @property param3 A description of the third function parameter
  * @property function the function implementation
  */
-@GenerativeBeta
 class ThreeParameterFunction<T, U, V>(
   name: String,
   description: String,
@@ -132,7 +128,6 @@ class ThreeParameterFunction<T, U, V>(
  * @property param4 A description of the fourth function parameter
  * @property function the function implementation
  */
-@GenerativeBeta
 class FourParameterFunction<T, U, V, W>(
   name: String,
   description: String,
@@ -153,7 +148,6 @@ class FourParameterFunction<T, U, V, W>(
   }
 }
 
-@GenerativeBeta
 abstract class FunctionDeclaration(val name: String, val description: String) {
   abstract fun getParameters(): List<Schema<out Any?>>
 
@@ -226,11 +220,9 @@ class Schema<T>(
   }
 }
 
-@GenerativeBeta
 fun defineFunction(name: String, description: String, function: suspend () -> JSONObject) =
   NoParameterFunction(name, description, function)
 
-@GenerativeBeta
 fun <T> defineFunction(
   name: String,
   description: String,
@@ -238,7 +230,6 @@ fun <T> defineFunction(
   function: suspend (T) -> JSONObject,
 ) = OneParameterFunction(name, description, arg1, function)
 
-@GenerativeBeta
 fun <T, U> defineFunction(
   name: String,
   description: String,
@@ -247,7 +238,6 @@ fun <T, U> defineFunction(
   function: suspend (T, U) -> JSONObject,
 ) = TwoParameterFunction(name, description, arg1, arg2, function)
 
-@GenerativeBeta
 fun <T, U, W> defineFunction(
   name: String,
   description: String,
@@ -257,7 +247,6 @@ fun <T, U, W> defineFunction(
   function: suspend (T, U, W) -> JSONObject,
 ) = ThreeParameterFunction(name, description, arg1, arg2, arg3, function)
 
-@GenerativeBeta
 fun <T, U, W, Z> defineFunction(
   name: String,
   description: String,

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Tool.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Tool.kt
@@ -22,7 +22,6 @@ package com.google.ai.client.generativeai.type
  *
  * @param functionDeclarations The set of functions that this tool allows the model access to
  */
-@OptIn(GenerativeBeta::class)
 class Tool(
   val functionDeclarations: List<FunctionDeclaration>,
 )

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/ToolConfig.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/ToolConfig.kt
@@ -22,7 +22,6 @@ package com.google.ai.client.generativeai.type
  *
  * @param functionCallingConfig The config for function calling
  */
-@OptIn(GenerativeBeta::class)
 class ToolConfig(val functionCallingConfig: FunctionCallingConfig) {
 
   companion object {


### PR DESCRIPTION
Per [b/337045627](https://b.corp.google.com/issues/337045627),

Since `v1beta` is now the default, we no longer have any need to require optin for certain features. The annotation itself has been left for future usage, but its actual usages have been removed.