### PR TITLE
Add responseMimeType support

### DIFF
--- a/.changes/common/advertisement-bit-appliance-beginner.json
+++ b/.changes/common/advertisement-bit-appliance-beginner.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Add support for responseMimeType"]}

--- a/.changes/common/bomb-creature-birth-arch.json
+++ b/.changes/common/bomb-creature-birth-arch.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Hide private JSON global property that was accidentally leaked into the public api"]}

--- a/.changes/generativeai/calendar-cherry-breath-arch.json
+++ b/.changes/generativeai/calendar-cherry-breath-arch.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Add support for responseMimeType"]}

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 
-private val JSON = Json {
+internal val JSON = Json {
   ignoreUnknownKeys = true
   prettyPrint = false
 }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 
-val JSON = Json {
+private val JSON = Json {
   ignoreUnknownKeys = true
   prettyPrint = false
 }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
@@ -27,6 +27,7 @@ data class GenerationConfig(
   @SerialName("candidate_count") val candidateCount: Int?,
   @SerialName("max_output_tokens") val maxOutputTokens: Int?,
   @SerialName("stop_sequences") val stopSequences: List<String>?,
+  @SerialName("response_mime_type") val responseMimeType: String?
 )
 
 @Serializable data class Tool(val functionDeclarations: List<FunctionDeclaration>)

--- a/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
@@ -21,15 +21,22 @@ import com.google.ai.client.generativeai.common.server.FinishReason
 import com.google.ai.client.generativeai.common.server.HarmProbability
 import com.google.ai.client.generativeai.common.server.HarmSeverity
 import com.google.ai.client.generativeai.common.shared.HarmCategory
+import com.google.ai.client.generativeai.common.shared.TextPart
 import com.google.ai.client.generativeai.common.util.goldenUnaryFile
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.Serializable
 import org.junit.Test
+
+@Serializable internal data class MountainColors(val name: String, val colors: List<String>)
 
 internal class UnarySnapshotTests {
   private val testTimeout = 5.seconds
@@ -192,6 +199,22 @@ internal class UnarySnapshotTests {
 
         response.candidates?.isEmpty() shouldBe false
         response.candidates?.first()?.citationMetadata?.citationSources?.isNotEmpty() shouldBe true
+      }
+    }
+
+  @Test
+  fun `properly translates json text`() =
+    goldenUnaryFile("success-constraint-decoding-json.json") {
+      withTimeout(testTimeout) {
+        val response = apiController.generateContent(textGenerateContentRequest("prompt"))
+
+        response.candidates?.isEmpty() shouldBe false
+        with(
+          response.candidates?.first()?.content?.parts?.first()?.shouldBeInstanceOf<TextPart>()
+        ) {
+          shouldNotBeNull()
+          JSON.decodeFromString<List<MountainColors>>(text).shouldNotBeEmpty()
+        }
       }
     }
 

--- a/common/src/test/resources/golden-files/unary/success-constraint-decoding-json.json
+++ b/common/src/test/resources/golden-files/unary/success-constraint-decoding-json.json
@@ -1,0 +1,34 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "[\n  {\n    \"name\": \"Fuji Dawn\",\n    \"colors\": [\n      \"#FEE4C4\",\n      \"#FCDEC0\",\n      \"#FBC7BB\",\n      \"#F2A194\",\n      \"#ED8571\"\n    ]\n  },\n  {\n    \"name\": \"Hawaiian Sunset\",\n    \"colors\": [\n      \"#F25C54\",\n      \"#F24545\",\n      \"#F22E35\",\n      \"#C92127\",\n      \"#96141A\"\n    ]\n  },\n  {\n    \"name\": \"Jakarta Noon\",\n    \"colors\": [\n      \"#037F8C\",\n      \"#026773\",\n      \"#014F59\",\n      \"#F2C777\",\n      \"#F2A857\"\n    ]\n  }\n]\n\n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        }
+      ]
+    }
+  ]
+}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
@@ -97,6 +97,7 @@ internal fun com.google.ai.client.generativeai.type.GenerationConfig.toInternal(
     candidateCount = candidateCount,
     maxOutputTokens = maxOutputTokens,
     stopSequences = stopSequences,
+    responseMimeType = responseMimeType
   )
 
 internal fun com.google.ai.client.generativeai.type.HarmCategory.toInternal() =

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
@@ -25,6 +25,9 @@ package com.google.ai.client.generativeai.type
  * @property candidateCount The max *unique* responses to return
  * @property maxOutputTokens The max tokens to generate per response
  * @property stopSequences A list of strings to stop generation on occurrence of
+ * @property responseMimeType Response type for generated candidate text. See the
+ *   [cloud docs](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/GenerationConfig)
+ *   for a list of supported types.
  */
 class GenerationConfig
 private constructor(
@@ -33,7 +36,8 @@ private constructor(
   val topP: Float?,
   val candidateCount: Int?,
   val maxOutputTokens: Int?,
-  val stopSequences: List<String>?
+  val stopSequences: List<String>?,
+  val responseMimeType: String?
 ) {
 
   class Builder {
@@ -43,6 +47,7 @@ private constructor(
     @JvmField var candidateCount: Int? = null
     @JvmField var maxOutputTokens: Int? = null
     @JvmField var stopSequences: List<String>? = null
+    @JvmField var responseMimeType: String? = null
 
     fun build() =
       GenerationConfig(
@@ -51,7 +56,8 @@ private constructor(
         topP = topP,
         candidateCount = candidateCount,
         maxOutputTokens = maxOutputTokens,
-        stopSequences = stopSequences
+        stopSequences = stopSequences,
+        responseMimeType = responseMimeType
       )
   }
 


### PR DESCRIPTION
Per [b/338414499](https://b.corp.google.com/issues/338414499),

This adds support for the `responseMimeType` property that was added to `GenerationConfig` of gemini.

This PR also fixes the following:
- [b/338415129](https://b.corp.google.com/issues/338415129) -> Hide leaked JSON property in common

DO_NOT_MERGE -> Wait until idea iteration is complete