### PR TITLE
Fix API warning task

### DIFF
--- a/plugins/src/main/java/com/google/gradle/plugins/ReleasePlugin.kt
+++ b/plugins/src/main/java/com/google/gradle/plugins/ReleasePlugin.kt
@@ -59,8 +59,7 @@ abstract class ReleasePlugin : Plugin<Project> {
       val deleteChangeFiles = tasks.named<Delete>("deleteChangeFiles")
 
       val releaseNotes = makeReleaseNotes.flatMap { it.outputFile }
-      val releasingVersion =
-        releaseNotes.map { parseReleaseVersion(it.asFile) }.orElse(moduleVersion)
+      val releasingVersion = releaseNotes.map { parseReleaseVersion(it.asFile, moduleVersion) }
 
       val updateVersion =
         tasks.register<VersionBumpTask>("updateVersion") {
@@ -96,7 +95,8 @@ abstract class ReleasePlugin : Plugin<Project> {
     }
   }
 
-  private fun parseReleaseVersion(releaseNotes: File): ModuleVersion {
+  private fun parseReleaseVersion(releaseNotes: File, fallback: ModuleVersion): ModuleVersion {
+    if (!releaseNotes.exists()) return fallback
     val version = releaseNotes.readFirstLine().substringAfter("#").trim()
 
     return ModuleVersion.fromStringOrNull(version)

--- a/plugins/src/main/java/com/google/gradle/tasks/CombineApiChangesTask.kt
+++ b/plugins/src/main/java/com/google/gradle/tasks/CombineApiChangesTask.kt
@@ -42,7 +42,7 @@ abstract class CombineApiChangesTask : DefaultTask() {
   @TaskAction
   fun add() {
     val projectNameToChangeFile =
-      apiChangesFiles.get().map { it.nameWithoutExtension to it.readText() }
+      apiChangesFiles.get().filter { it.exists() }.map { it.nameWithoutExtension to it.readText() }
 
     val texts = projectNameToChangeFile.joinToString("\n\n") { spoiler(it.first, it.second) }
 

--- a/plugins/src/main/java/com/google/gradle/tasks/CombineReleaseNotesTask.kt
+++ b/plugins/src/main/java/com/google/gradle/tasks/CombineReleaseNotesTask.kt
@@ -48,7 +48,7 @@ abstract class CombineReleaseNotesTask : DefaultTask() {
   @TaskAction
   fun add() {
     val projectNameToReleaseNotes =
-      releaseNoteFiles.get().map { it.nameWithoutExtension to it.readText() }
+      releaseNoteFiles.get().filter { it.exists() }.map { it.nameWithoutExtension to it.readText() }
 
     val texts =
       projectNameToReleaseNotes.map {

--- a/plugins/src/main/java/com/google/gradle/tasks/MakeReleaseNotesTask.kt
+++ b/plugins/src/main/java/com/google/gradle/tasks/MakeReleaseNotesTask.kt
@@ -21,7 +21,6 @@ import com.google.gradle.types.ModuleVersion
 import com.google.gradle.types.VersionType
 import java.io.File
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property


### PR DESCRIPTION
Per [b/338644141](https://b.corp.google.com/issues/338644141),

This fixes the `warnAboutAPIChanges` task that was failing when one of the projects didn't have any changes. This was due to an oversight in how Gradle propagates skipped properties. We've ran into this before, but it's easy to forget that even if a task is skipped- Gradle still considers outputs to be valid (even if they don't exist). So mapping against it doesn't provide the expected behavior. You can read more about this on their repo: [/gradle/issues/7442](https://github.com/gradle/gradle/issues/7442)

This PR also fixes the following:
- [b/338643118](https://b.corp.google.com/issues/338643118) -> Allow release tasks to work without files existing

