### PR TITLE
Add common proguard rules

### DIFF
--- a/common/consumer-rules.pro
+++ b/common/consumer-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.google.ai.client.generativeai.common.** { *; }


### PR DESCRIPTION
When we migrated to common, our types got moved and the proguard rule no longer applied. I think this should be adequate to handle all of our serialized types, but if there are more outside of common that'll also need to be kept.