### PR TITLE
Add missing serialization definitions for common

### DIFF
--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
@@ -27,7 +27,9 @@ data class GenerationConfig(
   @SerialName("candidate_count") val candidateCount: Int?,
   @SerialName("max_output_tokens") val maxOutputTokens: Int?,
   @SerialName("stop_sequences") val stopSequences: List<String>?,
-  @SerialName("response_mime_type") val responseMimeType: String?
+  @SerialName("response_mime_type") val responseMimeType: String? = null,
+  @SerialName("presence_penalty") val presencePenalty: Float? = null,
+  @SerialName("frequency_penalty") val frequencyPenalty: Float? = null,
 )
 
 @Serializable data class Tool(val functionDeclarations: List<FunctionDeclaration>)

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
@@ -53,7 +53,8 @@ data class Candidate(
   val content: Content? = null,
   val finishReason: FinishReason? = null,
   val safetyRatings: List<SafetyRating>? = null,
-  val citationMetadata: CitationMetadata? = null
+  val citationMetadata: CitationMetadata? = null,
+  val groundingMetadata: GroundingMetadata? = null,
 )
 
 @Serializable
@@ -77,6 +78,32 @@ data class SafetyRating(
   val probabilityScore: Float? = null,
   val severity: HarmSeverity? = null,
   val severityScore: Float? = null,
+)
+
+@Serializable
+data class GroundingMetadata(
+  @SerialName("web_search_queries") val webSearchQueries: List<String>?,
+  @SerialName("search_entry_point") val searchEntryPoint: SearchEntryPoint?,
+  @SerialName("retrieval_queries") val retrievalQueries: List<String>?,
+  @SerialName("grounding_attribution") val groundingAttribution: List<GroundingAttribution>?,
+)
+
+@Serializable
+data class SearchEntryPoint(
+  @SerialName("rendered_content") val renderedContent: String?,
+  @SerialName("sdk_blob") val sdkBlob: String?,
+)
+
+@Serializable
+data class GroundingAttribution(
+  val segment: Segment,
+  @SerialName("confidence_score") val confidenceScore: Float?,
+)
+
+@Serializable
+data class Segment(
+  @SerialName("start_index") val startIndex: Int,
+  @SerialName("end_index") val endIndex: Int,
 )
 
 @Serializable(HarmProbabilitySerializer::class)

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -76,7 +76,11 @@ data class Blob(
 )
 
 @Serializable
-data class SafetySetting(val category: HarmCategory, val threshold: HarmBlockThreshold)
+data class SafetySetting(
+  val category: HarmCategory,
+  val threshold: HarmBlockThreshold,
+  val method: HarmBlockMethod? = null,
+)
 
 @Serializable
 enum class HarmBlockThreshold {
@@ -85,6 +89,13 @@ enum class HarmBlockThreshold {
   BLOCK_MEDIUM_AND_ABOVE,
   BLOCK_ONLY_HIGH,
   BLOCK_NONE,
+}
+
+@Serializable
+enum class HarmBlockMethod {
+  @SerialName("HARM_BLOCK_METHOD_UNSPECIFIED") UNSPECIFIED,
+  SEVERITY,
+  PROBABILITY,
 }
 
 object PartSerializer : JsonContentPolymorphicSerializer<Part>(Part::class) {


### PR DESCRIPTION
This adds a handful of missing serialization definitions we were missing that are not in beta and we could be using in libraries depending on common. Tested to not cause issues with labs.