### PR TITLE
Update ktfmt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.8.20" apply false
     kotlin("android") version "1.8.22" apply false
     kotlin("plugin.serialization") version "1.8.22" apply false
-    id("com.ncorti.ktfmt.gradle") version "0.16.0" apply false
+    id("com.ncorti.ktfmt.gradle") version "0.18.0" apply false
     id("license-plugin")
     id("multi-project-plugin")
 }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -72,7 +72,7 @@ internal constructor(
   private val requestOptions: RequestOptions,
   httpEngine: HttpClientEngine,
   private val apiClient: String,
-  private val headerProvider: HeaderProvider?
+  private val headerProvider: HeaderProvider?,
 ) {
 
   constructor(
@@ -80,7 +80,7 @@ internal constructor(
     model: String,
     requestOptions: RequestOptions,
     apiClient: String,
-    headerProvider: HeaderProvider? = null
+    headerProvider: HeaderProvider? = null,
   ) : this(key, model, requestOptions, OkHttp.create(), apiClient, headerProvider)
 
   private val model = fullModelName(model)

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/Response.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/Response.kt
@@ -27,7 +27,7 @@ sealed interface Response
 data class GenerateContentResponse(
   val candidates: List<Candidate>? = null,
   val promptFeedback: PromptFeedback? = null,
-  val usageMetadata: UsageMetadata? = null
+  val usageMetadata: UsageMetadata? = null,
 ) : Response
 
 @Serializable
@@ -40,5 +40,5 @@ data class CountTokensResponse(val totalTokens: Int, val totalBillableCharacters
 data class UsageMetadata(
   val promptTokenCount: Int? = null,
   val candidatesTokenCount: Int? = null,
-  val totalTokenCount: Int? = null
+  val totalTokenCount: Int? = null,
 )

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
@@ -51,11 +51,7 @@ data class FunctionCallingConfig(val mode: Mode) {
 }
 
 @Serializable
-data class FunctionDeclaration(
-  val name: String,
-  val description: String,
-  val parameters: Schema,
-)
+data class FunctionDeclaration(val name: String, val description: String, val parameters: Schema)
 
 @Serializable
 data class Schema(

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
@@ -67,7 +67,7 @@ data class CitationSources(
   val startIndex: Int = 0,
   val endIndex: Int,
   val uri: String,
-  val license: String? = null
+  val license: String? = null,
 )
 
 @Serializable
@@ -138,10 +138,6 @@ enum class FinishReason {
 }
 
 @Serializable
-data class GRpcError(
-  val code: Int,
-  val message: String,
-  val details: List<GRpcErrorDetails>,
-)
+data class GRpcError(val code: Int, val message: String, val details: List<GRpcErrorDetails>)
 
 @Serializable data class GRpcErrorDetails(val reason: String? = null)

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -66,14 +66,10 @@ data class Content(@EncodeDefault val role: String? = "user", val parts: List<Pa
 @Serializable
 data class FileData(
   @SerialName("mime_type") val mimeType: String,
-  @SerialName("file_uri") val fileUri: String
+  @SerialName("file_uri") val fileUri: String,
 )
 
-@Serializable
-data class Blob(
-  @SerialName("mime_type") val mimeType: String,
-  val data: Base64,
-)
+@Serializable data class Blob(@SerialName("mime_type") val mimeType: String, val data: Base64)
 
 @Serializable
 data class SafetySetting(

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/util/serialization.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/util/serialization.kt
@@ -55,7 +55,7 @@ class FirstOrdinalSerializer<T : Enum<T>>(private val enumClass: KClass<T>) : KS
         |GitHub to bring it to our attention:
         |https://github.com/google/google-ai-android
        """
-        .trimMargin()
+        .trimMargin(),
     )
   }
 

--- a/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
@@ -95,7 +95,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         "genai-android/${BuildConfig.VERSION_NAME}",
-        null
+        null,
       )
 
     withTimeout(5.seconds) {
@@ -122,7 +122,7 @@ internal class RequestFormatTests {
         RequestOptions(endpoint = "https://my.custom.endpoint"),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) {
@@ -149,7 +149,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) {
@@ -179,7 +179,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) { controller.countTokens(textCountTokenRequest("cats")) }
@@ -203,7 +203,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) { controller.countTokens(textCountTokenRequest("cats")) }
@@ -226,7 +226,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) {
@@ -239,7 +239,7 @@ internal class RequestFormatTests {
               ToolConfig(
                 functionCallingConfig =
                   FunctionCallingConfig(mode = FunctionCallingConfig.Mode.AUTO)
-              )
+              ),
           )
         )
         .collect { channel.close() }
@@ -273,7 +273,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        testHeaderProvider
+        testHeaderProvider,
       )
 
     withTimeout(5.seconds) { controller.countTokens(textCountTokenRequest("cats")) }
@@ -307,7 +307,7 @@ internal class RequestFormatTests {
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        testHeaderProvider
+        testHeaderProvider,
       )
 
     withTimeout(5.seconds) { controller.countTokens(textCountTokenRequest("cats")) }
@@ -333,7 +333,7 @@ internal class ModelNamingTests(private val modelName: String, private val actua
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
-        null
+        null,
       )
 
     withTimeout(5.seconds) {
@@ -363,7 +363,7 @@ internal class ModelNamingTests(private val modelName: String, private val actua
 fun textGenerateContentRequest(prompt: String) =
   GenerateContentRequest(
     model = "unused",
-    contents = listOf(Content(parts = listOf(TextPart(prompt))))
+    contents = listOf(Content(parts = listOf(TextPart(prompt)))),
   )
 
 fun textCountTokenRequest(prompt: String) =

--- a/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
@@ -100,7 +100,7 @@ internal typealias CommonTest = suspend CommonTestScope.() -> Unit
 internal fun commonTest(
   status: HttpStatusCode = HttpStatusCode.OK,
   requestOptions: RequestOptions = RequestOptions(),
-  block: CommonTest
+  block: CommonTest,
 ) = doBlocking {
   val channel = ByteChannel(autoFlush = true)
   val mockEngine = MockEngine {
@@ -113,7 +113,7 @@ internal fun commonTest(
       requestOptions,
       mockEngine,
       TEST_CLIENT_ID,
-      null
+      null,
     )
   CommonTestScope(channel, apiController).block()
 }
@@ -132,7 +132,7 @@ internal fun commonTest(
 internal fun goldenStreamingFile(
   name: String,
   httpStatusCode: HttpStatusCode = HttpStatusCode.OK,
-  block: CommonTest
+  block: CommonTest,
 ) = doBlocking {
   val goldenFile = loadGoldenFile("streaming/$name")
   val messages = goldenFile.readLines().filter { it.isNotBlank() }
@@ -162,7 +162,7 @@ internal fun goldenStreamingFile(
 internal fun goldenUnaryFile(
   name: String,
   httpStatusCode: HttpStatusCode = HttpStatusCode.OK,
-  block: CommonTest
+  block: CommonTest,
 ) =
   commonTest(httpStatusCode) {
     val goldenFile = loadGoldenFile("unary/$name")

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
@@ -98,7 +98,7 @@ internal fun com.google.ai.client.generativeai.type.GenerationConfig.toInternal(
     candidateCount = candidateCount,
     maxOutputTokens = maxOutputTokens,
     stopSequences = stopSequences,
-    responseMimeType = responseMimeType
+    responseMimeType = responseMimeType,
   )
 
 internal fun com.google.ai.client.generativeai.type.HarmCategory.toInternal() =
@@ -203,10 +203,7 @@ internal fun Part.toPublic(): com.google.ai.client.generativeai.type.Part {
         functionResponse.response.toPublic(),
       )
     is FileDataPart ->
-      com.google.ai.client.generativeai.type.FileDataPart(
-        fileData.fileUri,
-        fileData.mimeType,
-      )
+      com.google.ai.client.generativeai.type.FileDataPart(fileData.fileUri, fileData.mimeType)
     else ->
       throw SerializationException(
         "Unsupported part type \"${javaClass.simpleName}\" provided. This model may not be supported by this SDK."
@@ -274,7 +271,7 @@ internal fun GenerateContentResponse.toPublic() =
   com.google.ai.client.generativeai.type.GenerateContentResponse(
     candidates?.map { it.toPublic() }.orEmpty(),
     promptFeedback?.toPublic(),
-    usageMetadata?.toPublic()
+    usageMetadata?.toPublic(),
   )
 
 internal fun CountTokensResponse.toPublic() =

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Candidate.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Candidate.kt
@@ -25,7 +25,7 @@ internal constructor(
   val content: Content,
   val safetyRatings: List<SafetyRating>,
   val citationMetadata: List<CitationMetadata>,
-  val finishReason: FinishReason?
+  val finishReason: FinishReason?,
 )
 
 /** Rating for a particular [HarmCategory] with a provided [HarmProbability]. */
@@ -44,7 +44,7 @@ class CitationMetadata(
   val startIndex: Int = 0,
   val endIndex: Int,
   val uri: String,
-  val license: String? = null
+  val license: String? = null,
 )
 
 /** The reason for content finishing. */

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerateContentResponse.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerateContentResponse.kt
@@ -28,7 +28,7 @@ import android.util.Log
 class GenerateContentResponse(
   val candidates: List<Candidate>,
   val promptFeedback: PromptFeedback?,
-  val usageMetadata: UsageMetadata?
+  val usageMetadata: UsageMetadata?,
 ) {
   /** Convenience field representing all the text parts in the response, if they exists. */
   val text: String? by lazy {

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
@@ -37,7 +37,7 @@ private constructor(
   val candidateCount: Int?,
   val maxOutputTokens: Int?,
   val stopSequences: List<String>?,
-  val responseMimeType: String?
+  val responseMimeType: String?,
 ) {
 
   class Builder {
@@ -57,7 +57,7 @@ private constructor(
         candidateCount = candidateCount,
         maxOutputTokens = maxOutputTokens,
         stopSequences = stopSequences,
-        responseMimeType = responseMimeType
+        responseMimeType = responseMimeType,
       )
   }
 

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/PromptFeedback.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/PromptFeedback.kt
@@ -22,10 +22,7 @@ package com.google.ai.client.generativeai.type
  * @param blockReason The reason that content was blocked, if at all.
  * @param safetyRatings A list of relevant [SafetyRating]s.
  */
-class PromptFeedback(
-  val blockReason: BlockReason?,
-  val safetyRatings: List<SafetyRating>,
-)
+class PromptFeedback(val blockReason: BlockReason?, val safetyRatings: List<SafetyRating>)
 
 /** Describes why content was blocked. */
 enum class BlockReason {

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
@@ -27,16 +27,10 @@ import kotlin.time.toDuration
  *   first response.
  * @property apiVersion the api endpoint to call.
  */
-class RequestOptions(
-  val timeout: Duration,
-  val apiVersion: String = "v1beta",
-) {
+class RequestOptions(val timeout: Duration, val apiVersion: String = "v1beta") {
   @JvmOverloads
   constructor(
     timeout: Long? = Long.MAX_VALUE,
     apiVersion: String = "v1beta",
-  ) : this(
-    (timeout ?: Long.MAX_VALUE).toDuration(DurationUnit.MILLISECONDS),
-    apiVersion,
-  )
+  ) : this((timeout ?: Long.MAX_VALUE).toDuration(DurationUnit.MILLISECONDS), apiVersion)
 }

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Tool.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Tool.kt
@@ -22,6 +22,4 @@ package com.google.ai.client.generativeai.type
  *
  * @param functionDeclarations The set of functions that this tool allows the model access to
  */
-class Tool(
-  val functionDeclarations: List<FunctionDeclaration>,
-)
+class Tool(val functionDeclarations: List<FunctionDeclaration>)

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/UsageMetadata.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/UsageMetadata.kt
@@ -26,5 +26,5 @@ package com.google.ai.client.generativeai.type
 class UsageMetadata(
   val promptTokenCount: Int,
   val candidatesTokenCount: Int,
-  val totalTokenCount: Int
+  val totalTokenCount: Int,
 )

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerateContentResponseTest.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerateContentResponseTest.kt
@@ -40,11 +40,11 @@ internal class GenerateContentResponseTest {
               },
               listOf(),
               listOf(),
-              null
+              null,
             )
           ),
         null,
-        null
+        null,
       )
 
     response.functionCalls shouldHaveSize 2
@@ -64,11 +64,11 @@ internal class GenerateContentResponseTest {
               },
               listOf(),
               listOf(),
-              null
+              null,
             )
           ),
         null,
-        null
+        null,
       )
 
     response.text shouldBe "This is a textPart"
@@ -89,11 +89,11 @@ internal class GenerateContentResponseTest {
               },
               listOf(),
               listOf(),
-              null
+              null,
             )
           ),
         null,
-        null
+        null,
       )
 
     response.text shouldBe "This is a textPart This is another textPart"

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
@@ -58,7 +58,7 @@ internal class GenerativeModelTests {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
           "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?"))))
+          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
     } returns
@@ -73,16 +73,11 @@ internal class GenerativeModelTests {
             safetyRatings = listOf(),
             citationMetadata =
               CitationMetadata_Common(
-                listOf(
-                  CitationSources(
-                    endIndex = 100,
-                    uri = "http://www.example.com",
-                  )
-                )
-              )
+                listOf(CitationSources(endIndex = 100, uri = "http://www.example.com"))
+              ),
           )
         ),
-        usageMetadata = UsageMetadata_Common(promptTokenCount = 10)
+        usageMetadata = UsageMetadata_Common(promptTokenCount = 10),
       )
 
     val expectedResponse =
@@ -97,14 +92,14 @@ internal class GenerativeModelTests {
                   startIndex = 0,
                   endIndex = 100,
                   uri = "http://www.example.com",
-                  license = null
+                  license = null,
                 )
               ),
-            finishReason = null
+            finishReason = null,
           )
         ),
         PromptFeedback(null, listOf()),
-        UsageMetadata(10, 0, 0 /* default to 0*/)
+        UsageMetadata(10, 0, 0 /* default to 0*/),
       )
 
     val response = model.generateContent("Why's the sky blue?")
@@ -114,7 +109,7 @@ internal class GenerativeModelTests {
     response.candidates[0].shouldBeEqualToUsingFields(
       expectedResponse.candidates[0],
       Candidate::finishReason,
-      Candidate::safetyRatings
+      Candidate::safetyRatings,
     )
     response.candidates[0]
       .citationMetadata[0]
@@ -134,7 +129,7 @@ internal class GenerativeModelTests {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
           "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?"))))
+          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
     } throws InvalidAPIKeyException_Common("exception message")
@@ -149,7 +144,7 @@ internal class GenerativeModelTests {
       mockApiController.generateContentStream(
         GenerateContentRequest_Common(
           "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?"))))
+          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
     } returns flow { throw UnsupportedUserLocationException_Common() }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
     kotlin("jvm") version "1.8.22"
-    id("com.ncorti.ktfmt.gradle") version "0.16.0"
+    id("com.ncorti.ktfmt.gradle") version "0.18.0"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
     kotlin("plugin.serialization") version "1.8.22"
 }

--- a/plugins/src/main/java/com/google/gradle/types/ModuleVersion.kt
+++ b/plugins/src/main/java/com/google/gradle/types/ModuleVersion.kt
@@ -138,7 +138,7 @@ data class ModuleVersion(
   val major: Int,
   val minor: Int,
   val patch: Int,
-  val pre: PreReleaseVersion? = null
+  val pre: PreReleaseVersion? = null,
 ) : Comparable<ModuleVersion>, Serializable {
 
   /** Formatted as `MAJOR.MINOR.PATCH-PRE` */
@@ -152,7 +152,7 @@ data class ModuleVersion(
       { it.minor },
       { it.patch },
       { it.pre == null }, // a version with no prerelease version takes precedence
-      { it.pre }
+      { it.pre },
     )
 
   companion object {
@@ -205,7 +205,7 @@ data class ModuleVersion(
                 major.toInt(),
                 minor.toInt(),
                 patch.toInt(),
-                PreReleaseVersion.fromStringsOrNull(pre, build)
+                PreReleaseVersion.fromStringsOrNull(pre, build),
               )
               .takeUnless { it.pre == null && (pre.isNotEmpty() || build.isNotEmpty()) }
           }


### PR DESCRIPTION
Per [b/343255536](https://b.corp.google.com/issues/343255536),

This update ktfmt to the latest version. This is needed to support a kmp migration, and the formatting changes from `0.16.0` to `0.18.0` are enough to pollute the kmp pr. So this change is being done separately to help reduce the diff in kmp related changes.