### PR TITLE
Make common parse lenient

### DIFF
--- a/.changes/common/distribution-doll-drop-bridge.json
+++ b/.changes/common/distribution-doll-drop-bridge.json
@@ -1,0 +1,1 @@
+{"type":"PATCH","changes":["Make JSON decoding lenient. This should fix issues with JSON literals."]}

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -52,6 +52,7 @@ import kotlinx.serialization.json.Json
 internal val JSON = Json {
   ignoreUnknownKeys = true
   prettyPrint = false
+  isLenient = true
 }
 
 /**

--- a/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
@@ -24,6 +24,7 @@ import com.google.ai.client.generativeai.common.shared.FunctionCallPart
 import com.google.ai.client.generativeai.common.shared.HarmCategory
 import com.google.ai.client.generativeai.common.shared.TextPart
 import com.google.ai.client.generativeai.common.util.goldenUnaryFile
+import com.google.ai.client.generativeai.common.util.shouldNotBeNullOrEmpty
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -311,6 +312,22 @@ internal class UnarySnapshotTests {
         val callPart = (response.candidates!!.first().content!!.parts.first() as FunctionCallPart)
 
         callPart.functionCall.args["season"] shouldBe null
+      }
+    }
+
+  @Test
+  fun `function call contains json literal`() =
+    goldenUnaryFile("success-function-call-json-literal.json") {
+      withTimeout(testTimeout) {
+        val response = apiController.generateContent(textGenerateContentRequest("prompt"))
+        val content = response.candidates.shouldNotBeNullOrEmpty().first().content
+        val callPart = content.let {
+          it.shouldNotBeNull()
+          it.parts.shouldNotBeEmpty()
+          it.parts.first().shouldBeInstanceOf<FunctionCallPart>()
+        }
+
+        callPart.functionCall.args["current"] shouldBe "true"
       }
     }
 }

--- a/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
@@ -321,11 +321,12 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
         val content = response.candidates.shouldNotBeNullOrEmpty().first().content
-        val callPart = content.let {
-          it.shouldNotBeNull()
-          it.parts.shouldNotBeEmpty()
-          it.parts.first().shouldBeInstanceOf<FunctionCallPart>()
-        }
+        val callPart =
+          content.let {
+            it.shouldNotBeNull()
+            it.parts.shouldNotBeEmpty()
+            it.parts.first().shouldBeInstanceOf<FunctionCallPart>()
+          }
 
         callPart.functionCall.args["current"] shouldBe "true"
       }

--- a/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
@@ -26,6 +26,8 @@ import com.google.ai.client.generativeai.common.RequestOptions
 import com.google.ai.client.generativeai.common.server.Candidate
 import com.google.ai.client.generativeai.common.shared.Content
 import com.google.ai.client.generativeai.common.shared.TextPart
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -184,3 +186,14 @@ internal fun loadGoldenFile(path: String): File = loadResourceFile("golden-files
 
 /** Loads a file from the test resources directory. */
 internal fun loadResourceFile(path: String) = File("src/test/resources/$path")
+
+/**
+ * Ensures that a collection is neither null or empty.
+ *
+ * Syntax sugar for [shouldNotBeNull] and [shouldNotBeEmpty].
+ */
+inline fun <reified T: Any> Collection<T>?.shouldNotBeNullOrEmpty(): Collection<T> {
+  shouldNotBeNull()
+  shouldNotBeEmpty()
+  return this
+}

--- a/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
@@ -192,7 +192,7 @@ internal fun loadResourceFile(path: String) = File("src/test/resources/$path")
  *
  * Syntax sugar for [shouldNotBeNull] and [shouldNotBeEmpty].
  */
-inline fun <reified T: Any> Collection<T>?.shouldNotBeNullOrEmpty(): Collection<T> {
+inline fun <reified T : Any> Collection<T>?.shouldNotBeNullOrEmpty(): Collection<T> {
   shouldNotBeNull()
   shouldNotBeEmpty()
   return this

--- a/common/src/test/resources/golden-files/unary/success-function-call-json-literal.json
+++ b/common/src/test/resources/golden-files/unary/success-function-call-json-literal.json
@@ -1,0 +1,45 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "functionName",
+              "args": {
+                "original_title": "String",
+                "current": true
+              }
+            }
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        }
+      ]
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 774,
+    "candidatesTokenCount": 4176,
+    "totalTokenCount": 4950
+  }
+}


### PR DESCRIPTION
Per [b/346812151](https://b.corp.google.com/issues/346812151),

This updates the json parser in common to be lenient in its decoding. Otherwise, it can not properly decode json literals such as:
```json
{
   "result": true
}
```

A test has been added to track this change as well.