### PR TITLE
Align proto primitives

### DIFF
--- a/.changes/common/breath-committee-dad-curtain.json
+++ b/.changes/common/breath-committee-dad-curtain.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Better align protos in regards to primitive defaults."]}

--- a/.changes/common/carpenter-beggar-creator-celery.json
+++ b/.changes/common/carpenter-beggar-creator-celery.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Better align protos in regards to primitive defaults."]}

--- a/.changes/generativeai/breath-brush-achiever-boat.json
+++ b/.changes/generativeai/breath-brush-achiever-boat.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Better align protos in regards to primitive defaults."]}

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -235,19 +235,19 @@ private suspend fun validateResponse(response: HttpResponse) {
   if (message.contains("quota")) {
     throw QuotaExceededException(message)
   }
-  if (error.details?.any { "SERVICE_DISABLED" == it.reason } == true) {
+  if (error.details.any { "SERVICE_DISABLED" == it.reason }) {
     throw ServiceDisabledException(message)
   }
   throw ServerException(message)
 }
 
 private fun GenerateContentResponse.validate() = apply {
-  if ((candidates?.isEmpty() != false) && promptFeedback == null) {
+  if (candidates.isEmpty() && promptFeedback == null) {
     throw SerializationException("Error deserializing response, found no valid fields")
   }
   promptFeedback?.blockReason?.let { throw PromptBlockedException(this) }
   candidates
-    ?.mapNotNull { it.finishReason }
-    ?.firstOrNull { it != FinishReason.STOP }
+    .map { it.finishReason }
+    .firstOrNull { it != FinishReason.STOP }
     ?.let { throw ResponseStoppedException(this) }
 }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/Exceptions.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/Exceptions.kt
@@ -96,7 +96,7 @@ class InvalidStateException(message: String, cause: Throwable? = null) :
  */
 class ResponseStoppedException(val response: GenerateContentResponse, cause: Throwable? = null) :
   GoogleGenerativeAIException(
-    "Content generation stopped. Reason: ${response.candidates?.first()?.finishReason?.name}",
+    "Content generation stopped. Reason: ${response.candidates.first().finishReason?.name}",
     cause,
   )
 

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/Response.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/Response.kt
@@ -25,20 +25,20 @@ sealed interface Response
 
 @Serializable
 data class GenerateContentResponse(
-  val candidates: List<Candidate>? = null,
+  val candidates: List<Candidate> = emptyList(),
   val promptFeedback: PromptFeedback? = null,
   val usageMetadata: UsageMetadata? = null,
 ) : Response
 
 @Serializable
-data class CountTokensResponse(val totalTokens: Int, val totalBillableCharacters: Int? = null) :
+data class CountTokensResponse(val totalTokens: Int = 0, val totalBillableCharacters: Int = 0) :
   Response
 
 @Serializable data class GRpcErrorResponse(val error: GRpcError) : Response
 
 @Serializable
 data class UsageMetadata(
-  val promptTokenCount: Int? = null,
-  val candidatesTokenCount: Int? = null,
-  val totalTokenCount: Int? = null,
+  val promptTokenCount: Int = 0,
+  val candidatesTokenCount: Int = 0,
+  val totalTokenCount: Int = 0,
 )

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/client/Types.kt
@@ -22,32 +22,30 @@ import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class GenerationConfig(
-  val temperature: Float?,
-  @SerialName("top_p") val topP: Float?,
-  @SerialName("top_k") val topK: Int?,
-  @SerialName("candidate_count") val candidateCount: Int?,
-  @SerialName("max_output_tokens") val maxOutputTokens: Int?,
-  @SerialName("stop_sequences") val stopSequences: List<String>?,
-  @SerialName("response_mime_type") val responseMimeType: String? = null,
-  @SerialName("presence_penalty") val presencePenalty: Float? = null,
-  @SerialName("frequency_penalty") val frequencyPenalty: Float? = null,
-  @SerialName("response_schema") val responseSchema: Schema? = null,
+  val temperature: Float = 0f,
+  val topP: Float = 0f,
+  val topK: Int = 0,
+  val candidateCount: Int = 0,
+  val maxOutputTokens: Int = 0,
+  val stopSequences: List<String> = emptyList(),
+  val responseMimeType: String = "",
+  val presencePenalty: Float = 0f,
+  val frequencyPenalty: Float = 0f,
+  val responseSchema: Schema? = null,
 )
 
 @Serializable
 data class Tool(
-  val functionDeclarations: List<FunctionDeclaration>? = null,
+  val functionDeclarations: List<FunctionDeclaration> = emptyList(),
   // This is a json object because it is not possible to make a data class with no parameters.
   val codeExecution: JsonObject? = null,
 )
 
 @Serializable
-data class ToolConfig(
-  @SerialName("function_calling_config") val functionCallingConfig: FunctionCallingConfig
-)
+data class ToolConfig(val functionCallingConfig: FunctionCallingConfig = FunctionCallingConfig())
 
 @Serializable
-data class FunctionCallingConfig(val mode: Mode) {
+data class FunctionCallingConfig(val mode: Mode? = null) {
   @Serializable
   enum class Mode {
     @SerialName("MODE_UNSPECIFIED") UNSPECIFIED,
@@ -58,16 +56,20 @@ data class FunctionCallingConfig(val mode: Mode) {
 }
 
 @Serializable
-data class FunctionDeclaration(val name: String, val description: String, val parameters: Schema)
+data class FunctionDeclaration(
+  val name: String,
+  val description: String,
+  val parameters: Schema? = null,
+)
 
 @Serializable
 data class Schema(
   val type: String,
-  val description: String? = null,
-  val format: String? = null,
-  val nullable: Boolean? = false,
-  val enum: List<String>? = null,
-  val properties: Map<String, Schema>? = null,
-  val required: List<String>? = null,
+  val description: String = "",
+  val format: String = "",
+  val nullable: Boolean = false,
+  val enum: List<String> = emptyList(),
+  val properties: Map<String, Schema> = emptyMap(),
+  val required: List<String> = emptyList(),
   val items: Schema? = null,
 )

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/server/Types.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.google.ai.client.generativeai.common.server
 
 import com.google.ai.client.generativeai.common.shared.Content
@@ -37,7 +39,7 @@ object FinishReasonSerializer :
 @Serializable
 data class PromptFeedback(
   val blockReason: BlockReason? = null,
-  val safetyRatings: List<SafetyRating>? = null,
+  val safetyRatings: List<SafetyRating> = emptyList(),
 )
 
 @Serializable(BlockReasonSerializer::class)
@@ -52,59 +54,51 @@ enum class BlockReason {
 data class Candidate(
   val content: Content? = null,
   val finishReason: FinishReason? = null,
-  val safetyRatings: List<SafetyRating>? = null,
+  val safetyRatings: List<SafetyRating> = emptyList(),
   val citationMetadata: CitationMetadata? = null,
   val groundingMetadata: GroundingMetadata? = null,
 )
 
 @Serializable
-data class CitationMetadata
-@OptIn(ExperimentalSerializationApi::class)
-constructor(@JsonNames("citations") val citationSources: List<CitationSources>)
+data class CitationMetadata(
+  @JsonNames("citations") val citationSources: List<CitationSources> = emptyList()
+)
 
 @Serializable
 data class CitationSources(
   val startIndex: Int = 0,
-  val endIndex: Int,
-  val uri: String,
-  val license: String? = null,
+  val endIndex: Int = 0,
+  val uri: String = "",
+  val license: String = "",
 )
 
 @Serializable
 data class SafetyRating(
   val category: HarmCategory,
   val probability: HarmProbability,
-  val blocked: Boolean? = null, // TODO(): any reason not to default to false?
-  val probabilityScore: Float? = null,
+  val blocked: Boolean = false,
+  val probabilityScore: Float = 0f,
   val severity: HarmSeverity? = null,
-  val severityScore: Float? = null,
+  val severityScore: Float = 0f,
 )
 
 @Serializable
 data class GroundingMetadata(
-  @SerialName("web_search_queries") val webSearchQueries: List<String>?,
-  @SerialName("search_entry_point") val searchEntryPoint: SearchEntryPoint?,
-  @SerialName("retrieval_queries") val retrievalQueries: List<String>?,
-  @SerialName("grounding_attribution") val groundingAttribution: List<GroundingAttribution>?,
+  val webSearchQueries: List<String> = emptyList(),
+  val searchEntryPoint: SearchEntryPoint? = null,
+  val retrievalQueries: List<String> = emptyList(),
+  val groundingAttribution: List<GroundingAttribution> = emptyList(),
 )
 
 @Serializable
-data class SearchEntryPoint(
-  @SerialName("rendered_content") val renderedContent: String?,
-  @SerialName("sdk_blob") val sdkBlob: String?,
-)
+data class SearchEntryPoint(val renderedContent: String = "", val sdkBlob: String = "")
 
+// TODO() Has a different definition for labs vs vertex. May need to split into diff types in future
+// (when labs supports it)
 @Serializable
-data class GroundingAttribution(
-  val segment: Segment,
-  @SerialName("confidence_score") val confidenceScore: Float?,
-)
+data class GroundingAttribution(val segment: Segment, val confidenceScore: Float = 0f)
 
-@Serializable
-data class Segment(
-  @SerialName("start_index") val startIndex: Int,
-  @SerialName("end_index") val endIndex: Int,
-)
+@Serializable data class Segment(val startIndex: Int = 0, val endIndex: Int = 0)
 
 @Serializable(HarmProbabilitySerializer::class)
 enum class HarmProbability {

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -45,13 +45,13 @@ typealias Base64 = String
 
 @ExperimentalSerializationApi
 @Serializable
-data class Content(@EncodeDefault val role: String? = "user", val parts: List<Part>)
+data class Content(@EncodeDefault val role: String = "", val parts: List<Part>)
 
 @Serializable(PartSerializer::class) sealed interface Part
 
-@Serializable data class TextPart(val text: String) : Part
+@Serializable data class TextPart(val text: String = "") : Part
 
-@Serializable data class BlobPart(@SerialName("inline_data") val inlineData: Blob) : Part
+@Serializable data class BlobPart(val inlineData: Blob) : Part
 
 @Serializable data class FunctionCallPart(val functionCall: FunctionCall) : Part
 
@@ -64,17 +64,14 @@ data class CodeExecutionResultPart(val codeExecutionResult: CodeExecutionResult)
 
 @Serializable data class FunctionResponse(val name: String, val response: JsonObject)
 
-@Serializable data class FunctionCall(val name: String, val args: Map<String, String?>)
-
-@Serializable data class FileDataPart(@SerialName("file_data") val fileData: FileData) : Part
-
 @Serializable
-data class FileData(
-  @SerialName("mime_type") val mimeType: String,
-  @SerialName("file_uri") val fileUri: String,
-)
+data class FunctionCall(val name: String, val args: Map<String, String?> = emptyMap())
 
-@Serializable data class Blob(@SerialName("mime_type") val mimeType: String, val data: Base64)
+@Serializable data class FileDataPart(val fileData: FileData) : Part
+
+@Serializable data class FileData(val mimeType: String, val fileUri: String)
+
+@Serializable data class Blob(val mimeType: String, val data: Base64)
 
 @Serializable data class ExecutableCode(val language: String, val code: String)
 

--- a/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class, ExperimentalSerializationApi::class)
+
 package com.google.ai.client.generativeai.common
 
 import com.google.ai.client.generativeai.common.client.FunctionCallingConfig
@@ -43,6 +45,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import org.junit.Test
@@ -64,7 +67,7 @@ internal class APIControllerTests {
 
     withTimeout(testTimeout) {
       responses.collect {
-        it.candidates?.isEmpty() shouldBe false
+        it.candidates.isEmpty() shouldBe false
         channel.close()
       }
     }
@@ -101,7 +104,7 @@ internal class RequestFormatTests {
 
     withTimeout(5.seconds) {
       controller.generateContentStream(textGenerateContentRequest("cats")).collect {
-        it.candidates?.isEmpty() shouldBe false
+        it.candidates.isEmpty() shouldBe false
         channel.close()
       }
     }
@@ -128,7 +131,7 @@ internal class RequestFormatTests {
 
     withTimeout(5.seconds) {
       controller.generateContentStream(textGenerateContentRequest("cats")).collect {
-        it.candidates?.isEmpty() shouldBe false
+        it.candidates.isEmpty() shouldBe false
         channel.close()
       }
     }
@@ -193,8 +196,7 @@ internal class RequestFormatTests {
     }
 
     val requestBodyAsText = (mockEngine.requestHistory.first().body as TextContent).text
-
-    requestBodyAsText shouldContainJsonKey "tool_config.function_calling_config.mode"
+    requestBodyAsText shouldContainJsonKey "toolConfig.functionCallingConfig.mode"
   }
 
   @Test
@@ -320,7 +322,7 @@ internal class ModelNamingTests(private val modelName: String, private val actua
 
     withTimeout(5.seconds) {
       controller.generateContentStream(textGenerateContentRequest("cats")).collect {
-        it.candidates?.isEmpty() shouldBe false
+        it.candidates.isEmpty() shouldBe false
         channel.close()
       }
     }
@@ -349,4 +351,4 @@ fun textGenerateContentRequest(prompt: String) =
   )
 
 fun textCountTokenRequest(prompt: String) =
-  CountTokensRequest(generateContentRequest = textGenerateContentRequest(prompt))
+  CountTokensRequest("", generateContentRequest = textGenerateContentRequest(prompt))

--- a/common/src/test/java/com/google/ai/client/generativeai/common/StreamingSnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/StreamingSnapshotTests.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.google.ai.client.generativeai.common
 
 import com.google.ai.client.generativeai.common.server.BlockReason
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.Test
 
 internal class StreamingSnapshotTests {
@@ -44,9 +47,9 @@ internal class StreamingSnapshotTests {
       withTimeout(testTimeout) {
         val responseList = responses.toList()
         responseList.isEmpty() shouldBe false
-        responseList.first().candidates?.first()?.finishReason shouldBe FinishReason.STOP
-        responseList.first().candidates?.first()?.content?.parts?.isEmpty() shouldBe false
-        responseList.first().candidates?.first()?.safetyRatings?.isEmpty() shouldBe false
+        responseList.first().candidates.first().finishReason shouldBe FinishReason.STOP
+        responseList.first().candidates.first().content?.parts?.isEmpty() shouldBe false
+        responseList.first().candidates.first().safetyRatings.isEmpty() shouldBe false
       }
     }
 
@@ -59,9 +62,9 @@ internal class StreamingSnapshotTests {
         val responseList = responses.toList()
         responseList.isEmpty() shouldBe false
         responseList.forEach {
-          it.candidates?.first()?.finishReason shouldBe FinishReason.STOP
-          it.candidates?.first()?.content?.parts?.isEmpty() shouldBe false
-          it.candidates?.first()?.safetyRatings?.isEmpty() shouldBe false
+          it.candidates.first().finishReason shouldBe FinishReason.STOP
+          it.candidates.first().content?.parts?.isEmpty() shouldBe false
+          it.candidates.first().safetyRatings.isEmpty() shouldBe false
         }
       }
     }
@@ -73,9 +76,7 @@ internal class StreamingSnapshotTests {
 
       withTimeout(testTimeout) {
         responses.first {
-          it.candidates?.any {
-            it.safetyRatings?.any { it.category == HarmCategory.UNKNOWN } ?: false
-          } ?: false
+          it.candidates.any { it.safetyRatings.any { it.category == HarmCategory.UNKNOWN } }
         }
       }
     }
@@ -89,7 +90,7 @@ internal class StreamingSnapshotTests {
         val responseList = responses.toList()
 
         responseList.isEmpty() shouldBe false
-        val part = responseList.first().candidates?.first()?.content?.parts?.first() as? TextPart
+        val part = responseList.first().candidates.first().content?.parts?.first() as? TextPart
         part.shouldNotBeNull()
         part.text shouldContain "\""
       }
@@ -129,7 +130,7 @@ internal class StreamingSnapshotTests {
 
       withTimeout(testTimeout) {
         val exception = shouldThrow<ResponseStoppedException> { responses.collect() }
-        exception.response.candidates?.first()?.finishReason shouldBe FinishReason.SAFETY
+        exception.response.candidates.first().finishReason shouldBe FinishReason.SAFETY
       }
     }
 
@@ -141,8 +142,7 @@ internal class StreamingSnapshotTests {
       withTimeout(testTimeout) {
         val responseList = responses.toList()
         responseList.any {
-          it.candidates?.any { it.citationMetadata?.citationSources?.isNotEmpty() ?: false }
-            ?: false
+          it.candidates.any { it.citationMetadata?.citationSources?.isNotEmpty() ?: false }
         } shouldBe true
       }
     }
@@ -155,8 +155,7 @@ internal class StreamingSnapshotTests {
       withTimeout(testTimeout) {
         val responseList = responses.toList()
         responseList.any {
-          it.candidates?.any { it.citationMetadata?.citationSources?.isNotEmpty() ?: false }
-            ?: false
+          it.candidates.any { it.citationMetadata?.citationSources?.isNotEmpty() ?: false }
         } shouldBe true
       }
     }
@@ -168,7 +167,7 @@ internal class StreamingSnapshotTests {
 
       withTimeout(testTimeout) {
         val exception = shouldThrow<ResponseStoppedException> { responses.collect() }
-        exception.response.candidates?.first()?.finishReason shouldBe FinishReason.RECITATION
+        exception.response.candidates.first().finishReason shouldBe FinishReason.RECITATION
       }
     }
 

--- a/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/UnarySnapshotTests.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.google.ai.client.generativeai.common
 
 import com.google.ai.client.generativeai.common.server.BlockReason
@@ -36,10 +38,12 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.HttpStatusCode
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import org.junit.Test
 
@@ -54,10 +58,10 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.finishReason shouldBe FinishReason.STOP
-        response.candidates?.first()?.content?.parts?.isEmpty() shouldBe false
-        response.candidates?.first()?.safetyRatings?.isEmpty() shouldBe false
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().finishReason shouldBe FinishReason.STOP
+        response.candidates.first().content?.parts?.isEmpty() shouldBe false
+        response.candidates.first().safetyRatings.isEmpty() shouldBe false
       }
     }
 
@@ -67,10 +71,10 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.finishReason shouldBe FinishReason.STOP
-        response.candidates?.first()?.content?.parts?.isEmpty() shouldBe false
-        response.candidates?.first()?.safetyRatings?.isEmpty() shouldBe false
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().finishReason shouldBe FinishReason.STOP
+        response.candidates.first().content?.parts?.isEmpty() shouldBe false
+        response.candidates.first().safetyRatings.isEmpty() shouldBe false
       }
     }
 
@@ -80,9 +84,7 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.first {
-          it.safetyRatings?.any { it.category == HarmCategory.UNKNOWN } ?: false
-        }
+        response.candidates.first { it.safetyRatings.any { it.category == HarmCategory.UNKNOWN } }
       }
     }
 
@@ -92,17 +94,16 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.safetyRatings?.isEmpty() shouldBe false
-        response.candidates?.first()?.safetyRatings?.all {
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().safetyRatings.isEmpty() shouldBe false
+        response.candidates.first().safetyRatings.all {
           it.probability == HarmProbability.NEGLIGIBLE
         } shouldBe true
-        response.candidates?.first()?.safetyRatings?.all { it.probabilityScore != null } shouldBe
-          true
-        response.candidates?.first()?.safetyRatings?.all {
+        response.candidates.first().safetyRatings.all { it.probabilityScore != 0f } shouldBe true
+        response.candidates.first().safetyRatings.all {
           it.severity == HarmSeverity.NEGLIGIBLE
         } shouldBe true
-        response.candidates?.first()?.safetyRatings?.all { it.severityScore != null } shouldBe true
+        response.candidates.first().safetyRatings.all { it.severityScore != 0f } shouldBe true
       }
     }
 
@@ -154,7 +155,7 @@ internal class UnarySnapshotTests {
           shouldThrow<ResponseStoppedException> {
             apiController.generateContent(textGenerateContentRequest("prompt"))
           }
-        exception.response.candidates?.first()?.finishReason shouldBe FinishReason.SAFETY
+        exception.response.candidates.first().finishReason shouldBe FinishReason.SAFETY
       }
     }
 
@@ -164,8 +165,8 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.citationMetadata?.citationSources?.isNotEmpty() shouldBe true
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().citationMetadata?.citationSources?.isNotEmpty() shouldBe true
       }
     }
 
@@ -175,11 +176,11 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.citationMetadata?.citationSources?.isNotEmpty() shouldBe true
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().citationMetadata?.citationSources?.isNotEmpty() shouldBe true
         // Verify the values in the citation source
-        with(response.candidates?.first()?.citationMetadata?.citationSources?.first()!!) {
-          license shouldBe null
+        with(response.candidates.first().citationMetadata?.citationSources?.first()!!) {
+          license.shouldBeEmpty()
           startIndex shouldBe 0
         }
       }
@@ -191,8 +192,8 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.finishReason shouldBe FinishReason.STOP
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().finishReason shouldBe FinishReason.STOP
         response.usageMetadata shouldNotBe null
         response.usageMetadata?.totalTokenCount shouldBe 363
       }
@@ -204,11 +205,11 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.finishReason shouldBe FinishReason.STOP
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().finishReason shouldBe FinishReason.STOP
         response.usageMetadata shouldNotBe null
         response.usageMetadata?.promptTokenCount shouldBe 6
-        response.usageMetadata?.totalTokenCount shouldBe null
+        response.usageMetadata?.totalTokenCount shouldBe 0
       }
     }
 
@@ -218,8 +219,8 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        response.candidates?.first()?.citationMetadata?.citationSources?.isNotEmpty() shouldBe true
+        response.candidates.isEmpty() shouldBe false
+        response.candidates.first().citationMetadata?.citationSources?.isNotEmpty() shouldBe true
       }
     }
 
@@ -229,10 +230,8 @@ internal class UnarySnapshotTests {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
 
-        response.candidates?.isEmpty() shouldBe false
-        with(
-          response.candidates?.first()?.content?.parts?.first()?.shouldBeInstanceOf<TextPart>()
-        ) {
+        response.candidates.isEmpty() shouldBe false
+        with(response.candidates.first().content?.parts?.first()?.shouldBeInstanceOf<TextPart>()) {
           shouldNotBeNull()
           JSON.decodeFromString<List<MountainColors>>(text).shouldNotBeEmpty()
         }
@@ -314,7 +313,7 @@ internal class UnarySnapshotTests {
     goldenUnaryFile("success-function-call-null.json") {
       withTimeout(testTimeout) {
         val response = apiController.generateContent(textGenerateContentRequest("prompt"))
-        val callPart = (response.candidates!!.first().content!!.parts.first() as FunctionCallPart)
+        val callPart = (response.candidates.first().content!!.parts.first() as FunctionCallPart)
 
         callPart.functionCall.args["season"] shouldBe null
       }

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -195,9 +195,9 @@ internal constructor(
     GenerateContentRequest(
       modelName,
       prompt.map { it.toInternal() },
-      safetySettings?.map { it.toInternal() },
+      safetySettings?.map { it.toInternal() }.orEmpty(),
       generationConfig?.toInternal(),
-      tools?.map { it.toInternal() },
+      tools?.map { it.toInternal() }.orEmpty(),
       toolConfig?.toInternal(),
       systemInstruction?.toInternal(),
     )
@@ -206,12 +206,12 @@ internal constructor(
     CountTokensRequest.forGenAI(constructRequest(*prompt))
 
   private fun GenerateContentResponse.validate() = apply {
-    if (candidates.isEmpty() && promptFeedback == null) {
+    if (candidates.isEmpty() && promptFeedback?.blockReason == null) {
       throw SerializationException("Error deserializing response, found no valid fields")
     }
     promptFeedback?.blockReason?.let { throw PromptBlockedException(this) }
     candidates
-      .mapNotNull { it.finishReason }
+      .map { it.finishReason }
       .firstOrNull { it != FinishReason.STOP }
       ?.let { throw ResponseStoppedException(this) }
   }

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Candidate.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Candidate.kt
@@ -44,7 +44,7 @@ class CitationMetadata(
   val startIndex: Int = 0,
   val endIndex: Int,
   val uri: String,
-  val license: String? = null,
+  val license: String,
 )
 
 /** The reason for content finishing. */

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Content.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Content.kt
@@ -25,12 +25,11 @@ import android.graphics.Bitmap
  *
  * @see content
  */
-class Content @JvmOverloads constructor(val role: String? = "user", val parts: List<Part>) {
+class Content @JvmOverloads constructor(val role: String = "user", val parts: List<Part>) {
 
   class Builder {
-    var role: String? = "user"
-
-    var parts: MutableList<Part> = arrayListOf()
+    var role: String = "user"
+    val parts: MutableList<Part> = arrayListOf()
 
     @JvmName("addPart") fun <T : Part> part(data: T) = apply { parts.add(data) }
 
@@ -59,7 +58,7 @@ class Content @JvmOverloads constructor(val role: String? = "user", val parts: L
  * )
  * ```
  */
-fun content(role: String? = "user", init: Content.Builder.() -> Unit): Content {
+fun content(role: String = "user", init: Content.Builder.() -> Unit): Content {
   val builder = Content.Builder()
   builder.role = role
   builder.init()

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionDeclarations.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionDeclarations.kt
@@ -52,11 +52,11 @@ class FunctionDeclaration(
 class Schema<T>(
   val name: String,
   val description: String,
-  val format: String? = null,
-  val nullable: Boolean? = null,
-  val enum: List<String>? = null,
-  val properties: Map<String, Schema<out Any>>? = null,
-  val required: List<String>? = null,
+  val format: String = "",
+  val nullable: Boolean = false,
+  val enum: List<String> = emptyList(),
+  val properties: Map<String, Schema<out Any>> = emptyMap(),
+  val required: List<String> = emptyList(),
   val items: Schema<out Any>? = null,
   val type: FunctionType<T>,
 ) {

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionParameter.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/FunctionParameter.kt
@@ -16,4 +16,4 @@
 
 package com.google.ai.client.generativeai.type
 
-class FunctionParameter<T>(val name: String, val description: String, val type: FunctionType<T>) {}
+class FunctionParameter<T>(val name: String, val description: String, val type: FunctionType<T>)

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/GenerationConfig.kt
@@ -31,24 +31,24 @@ package com.google.ai.client.generativeai.type
  */
 class GenerationConfig
 private constructor(
-  val temperature: Float?,
-  val topK: Int?,
-  val topP: Float?,
-  val candidateCount: Int?,
-  val maxOutputTokens: Int?,
-  val stopSequences: List<String>?,
-  val responseMimeType: String?,
+  val temperature: Float,
+  val topK: Int,
+  val topP: Float,
+  val candidateCount: Int,
+  val maxOutputTokens: Int,
+  val stopSequences: List<String> = emptyList(),
+  val responseMimeType: String,
   val responseSchema: Schema<*>?,
 ) {
 
   class Builder {
-    @JvmField var temperature: Float? = null
-    @JvmField var topK: Int? = null
-    @JvmField var topP: Float? = null
-    @JvmField var candidateCount: Int? = null
-    @JvmField var maxOutputTokens: Int? = null
-    @JvmField var stopSequences: List<String>? = null
-    @JvmField var responseMimeType: String? = null
+    @JvmField var temperature: Float = 0f
+    @JvmField var topK: Int = 0
+    @JvmField var topP: Float = 0f
+    @JvmField var candidateCount: Int = 1
+    @JvmField var maxOutputTokens: Int = 0
+    @JvmField var stopSequences: List<String> = emptyList()
+    @JvmField var responseMimeType: String = ""
     @JvmField var responseSchema: Schema<*>? = null
 
     fun build() =

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/PromptFeedback.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/PromptFeedback.kt
@@ -22,7 +22,10 @@ package com.google.ai.client.generativeai.type
  * @param blockReason The reason that content was blocked, if at all.
  * @param safetyRatings A list of relevant [SafetyRating]s.
  */
-class PromptFeedback(val blockReason: BlockReason?, val safetyRatings: List<SafetyRating>)
+class PromptFeedback(
+  val blockReason: BlockReason? = null,
+  val safetyRatings: List<SafetyRating> = emptyList(),
+)
 
 /** Describes why content was blocked. */
 enum class BlockReason {

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/SafetySetting.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/SafetySetting.kt
@@ -22,4 +22,4 @@ package com.google.ai.client.generativeai.type
  * @param harmCategory The relevant [HarmCategory].
  * @param threshold The threshold form harm allowable.
  */
-class SafetySetting(val harmCategory: HarmCategory, val threshold: BlockThreshold) {}
+class SafetySetting(val harmCategory: HarmCategory, val threshold: BlockThreshold)

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package com.google.ai.client.generativeai
 
 import com.google.ai.client.generativeai.common.APIController
@@ -54,6 +56,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
 import org.json.JSONObject
 import org.junit.Test
 
@@ -69,7 +72,10 @@ internal class GenerativeModelTests {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
           "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
+          contents =
+            listOf(
+              Content_Common(role = "user", parts = listOf(TextPart_Common("Why's the sky blue?")))
+            ),
         )
       )
     } returns
@@ -78,7 +84,8 @@ internal class GenerativeModelTests {
           Candidate_Common(
             content =
               Content_Common(
-                parts = listOf(TextPart_Common("I'm still learning how to answer this question"))
+                role = "user",
+                parts = listOf(TextPart_Common("I'm still learning how to answer this question")),
               ),
             finishReason = null,
             safetyRatings = listOf(),
@@ -103,7 +110,7 @@ internal class GenerativeModelTests {
                   startIndex = 0,
                   endIndex = 100,
                   uri = "http://www.example.com",
-                  license = null,
+                  license = "",
                 )
               ),
             finishReason = null,
@@ -139,8 +146,11 @@ internal class GenerativeModelTests {
     coEvery {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
-          "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
+          model = "gemini-pro-1.0",
+          contents =
+            listOf(
+              Content_Common(role = "user", parts = listOf(TextPart_Common("Why's the sky blue?")))
+            ),
         )
       )
     } throws InvalidAPIKeyException_Common("exception message")
@@ -155,7 +165,10 @@ internal class GenerativeModelTests {
       mockApiController.generateContentStream(
         GenerateContentRequest_Common(
           "gemini-pro-1.0",
-          contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
+          contents =
+            listOf(
+              Content_Common(role = "user", parts = listOf(TextPart_Common("Why's the sky blue?")))
+            ),
         )
       )
     } returns flow { throw UnsupportedUserLocationException_Common() }


### PR DESCRIPTION
Per [b/346838276](https://b.corp.google.com/issues/346838276),

This better aligns our serialization with the default behavior of the proto. More specifically- primitive defaults, and empty lists. Other default behaviors could be addressed as well- such as `UNSPECIFIED` for enum values, but that has been put off for now as it will have design implications (eg; `FinishReason` no longer being null).

This PR also fixes the following:

[b/350773404](https://b.corp.google.com/issues/350773404) -> Stop using snake case serial names