### PR TITLE
Bump sample app for 0.9.0

### DIFF
--- a/generativeai-android-sample/app/build.gradle.kts
+++ b/generativeai-android-sample/app/build.gradle.kts
@@ -75,5 +75,5 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
-    implementation("com.google.ai.client.generativeai:generativeai:0.7.0")
+    implementation("com.google.ai.client.generativeai:generativeai:0.9.0")
 }


### PR DESCRIPTION
Per [b/350811149](https://b.corp.google.com/issues/350811149),

This bumps the sample app version to `0.9.0` to align with the most recent release.