### PR TITLE
Fix streaming unknown enum test

### DIFF
--- a/common/src/test/java/com/google/ai/client/generativeai/common/StreamingSnapshotTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/StreamingSnapshotTests.kt
@@ -72,11 +72,13 @@ internal class StreamingSnapshotTests {
       val responses = apiController.generateContentStream(textGenerateContentRequest("prompt"))
 
       withTimeout(testTimeout) {
-        responses.first {
+        val responseList = responses.toList()
+        responseList.isEmpty() shouldBe false
+        responseList.any {
           it.candidates?.any {
             it.safetyRatings?.any { it.category == HarmCategory.UNKNOWN } ?: false
           } ?: false
-        }
+        } shouldBe true
       }
     }
 


### PR DESCRIPTION
The unary version was fixed in [13b4d44](https://github.com/google-gemini/generative-ai-android/commit/13b4d448c816b111fc1c81327c2cb72ab7e0ba9b)