### PR TITLE
Use 1.5 instead of 1.0 in tests

### DIFF
--- a/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
@@ -92,7 +92,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         "genai-android/${BuildConfig.VERSION_NAME}",
@@ -119,7 +119,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(endpoint = "https://my.custom.endpoint"),
         mockEngine,
         TEST_CLIENT_ID,
@@ -146,7 +146,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -169,7 +169,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -216,7 +216,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -250,7 +250,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,
@@ -273,7 +273,7 @@ internal class RequestFormatTests {
     val controller =
       APIController(
         "super_cool_test_key",
-        "gemini-pro-1.0",
+        "gemini-pro-1.5",
         RequestOptions(),
         mockEngine,
         TEST_CLIENT_ID,

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
@@ -64,11 +64,11 @@ internal class GenerativeModelTests {
 
   @Test
   fun `generateContent request succeeds`() = doBlocking {
-    val model = GenerativeModel("gemini-pro-1.0", apiKey, controller = mockApiController)
+    val model = GenerativeModel("gemini-pro-1.5", apiKey, controller = mockApiController)
     coEvery {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
-          "gemini-pro-1.0",
+          "gemini-pro-1.5",
           contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
@@ -135,11 +135,11 @@ internal class GenerativeModelTests {
 
   @Test
   fun `generateContent throws exception`() = doBlocking {
-    val model = GenerativeModel("gemini-pro-1.0", apiKey, controller = mockApiController)
+    val model = GenerativeModel("gemini-pro-1.5", apiKey, controller = mockApiController)
     coEvery {
       mockApiController.generateContent(
         GenerateContentRequest_Common(
-          "gemini-pro-1.0",
+          "gemini-pro-1.5",
           contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
@@ -150,11 +150,11 @@ internal class GenerativeModelTests {
 
   @Test
   fun `generateContentStream throws exception`() = doBlocking {
-    val model = GenerativeModel("gemini-pro-1.0", apiKey, controller = mockApiController)
+    val model = GenerativeModel("gemini-pro-1.5", apiKey, controller = mockApiController)
     coEvery {
       mockApiController.generateContentStream(
         GenerateContentRequest_Common(
-          "gemini-pro-1.0",
+          "gemini-pro-1.5",
           contents = listOf(Content_Common(parts = listOf(TextPart_Common("Why's the sky blue?")))),
         )
       )
@@ -180,7 +180,7 @@ internal class GenerativeModelTests {
       )
     val tools = listOf(Tool(listOf(getExchangeRate)))
     val model =
-      GenerativeModel("gemini-pro-1.0", apiKey, tools = tools, controller = mockApiController)
+      GenerativeModel("gemini-pro-1.5", apiKey, tools = tools, controller = mockApiController)
     val chat = Chat(model)
 
     coEvery { mockApiController.generateContent(any()) } returns


### PR DESCRIPTION
Per [b/348216210](https://b.corp.google.com/issues/348216210),

This addresses some comments left in a previous PR. More specifically, it updates our tests to use `1.5` instead of `1.0` so that we better align with expected usage.